### PR TITLE
use non-ssl m2.duraspace.org repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,16 @@
 		</testResources>
 	</build>
 
+  <repositories>
+    <repository>
+      <id>m2-duraspace</id>
+      <url>http://m2.duraspace.org/content/repositories/releases</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+  </repositories>
+
 	<dependencies>
     <dependency>
       <groupId>org.fcrepo</groupId>


### PR DESCRIPTION
The m2.duraspace.org repository has a misconfigured SSL cert. This uses the plain HTTP (non-ssl) version of the repo.