### PR TITLE
Release 7.1.9 (Islandora 7.x-1.9) bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,20 +3,22 @@
     <groupId>ca.islandora</groupId>
     <artifactId>fcrepo-drupalauthfilter</artifactId>
     <name>Islandora Drupal Servlet Filters</name>
-    <version>${fedora.version}</version>
+    <version>7.1.9</version>
     <modelVersion>4.0.0</modelVersion>
-
     <properties>
         <skipTests>true</skipTests>
         <fedora.version>3.6.2</fedora.version>
     </properties>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
+                <configuration>
+                    <finalName>fcrepo-drupalauthfilter</finalName>
+                    <classifier>${fedora.version}</classifier>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -245,4 +247,12 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
+
+    <repositories>
+        <repository>
+            <id>fast-md5</id>
+            <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
+        </repository>
+    </repositories>
+    
 </project>


### PR DESCRIPTION
Packaging updates to be able to publish all release JAR files


# What does this Pull Request do?

- Defines 7.1.9 as artifact version in our POM.XML
- makes use of classifier tag to mark/state the use of different `fcrepo` version dependencies for the generated JAR files
- Fixes a nonexisting, not updated, fast-md5 repository URL from maven central that breaks packaging. Sadly the original URL went offline April 2017, just a  few days ago.

# What's new?

We define versioning inside the artifact now. Also, to keep the current naming convention I had to move a bit the jar naming. MVN (and I) would love to name the jar files fcrepo-drupalauthfilter-7.1.9-fcp3.5.jar or something like that (which is the default nomenclature for `artifactId:versionId:classifier:packagetype`) or close to that, working this from my memory so can be a bit different.

# How should this be tested?

Apply and run `mvn package -Dfedora.version=3.5`, you should get a nice jar file

Don't apply and packaging should fail but also version will be stuck to fedora one, wich is weird.

# Additional Notes:

- Was discussed multiple times in Committers calls. 
- It's a mix of "going forward" and "not breaking backward".
- We need to update WIKI once this gets merged and the filter is released
- Release will contain this fcrepo target versions https://repo.maven.apache.org/maven2/org/fcrepo/fcrepo-common/

# Interested parties
@dannylamb @adam-vessey 