### PR TITLE
Master equivalent to 7.x-1.9 release one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,20 +3,22 @@
     <groupId>ca.islandora</groupId>
     <artifactId>fcrepo-drupalauthfilter</artifactId>
     <name>Islandora Drupal Servlet Filters</name>
-    <version>${fedora.version}</version>
+    <version>7.1.10-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
-
     <properties>
         <skipTests>true</skipTests>
         <fedora.version>3.6.2</fedora.version>
     </properties>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
+                <configuration>
+                    <finalName>fcrepo-drupalauthfilter</finalName>
+                    <classifier>${fedora.version}</classifier>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -245,4 +247,12 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
+
+    <repositories>
+        <repository>
+            <id>fast-md5</id>
+            <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
+        </repository>
+    </repositories>
+
 </project>


### PR DESCRIPTION


Packaging updates to be able to publish all release JAR files

# What does this Pull Request do?

- Defines 7.1.10-SNAPSHOT as artifact version in our POM.XML for master branch.  Means not yet 7.1.10, dev version.

Note : Also, trying to be JAVA aware here. 7.1.10-SNAPSHOT is semantically equivalent to our 7.x-1.x thing in islandora. Means not release, in between releases, will eventually become 7.1.10 version but right now WIP/dev version after 7.1.9

- makes use of classifier tag to mark/state the use of different `fcrepo` version dependencies for the generated JAR files
- Fixes a nonexisting, not updated, fast-md5 repository URL from maven central that breaks packaging. Sadly the original URL went offline April 2017, just a  few days ago.

# What's new?

See #22 

# Interested parties
@dannylamb @adam-vessey 