### PR TITLE
ISLANDORA-2074: Travis-CI updates on our JAVA test matrix (#1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,57 @@
+dist: trusty
+#Docker container based
 sudo: false
 language: java
 cache:
   directories:
   - $HOME/.m2
+
 jdk:
-  - openjdk6
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
 env:
   - FEDORA_VERSION=3.6.2
   - FEDORA_VERSION=3.7.0
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
+matrix:
+  include:
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.6.2"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+         - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.7.0"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+        - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.7.1"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+        - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.8.1"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+       - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+  allow_failures:
+    - jdk: oraclejdk9
+
 script:
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=travis -Ddb.pass=""
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=postgres -Ddb.pass="" -Ddb.port=5432 -Ddb.class="org.postgresql.Driver" -Ddb.scheme="jdbc:postgresql" -Ddb.group=postgresql -Ddb.artifact=postgresql -Ddb.version="9.1-901.jdbc4"

--- a/tests/scripts/mavenforopenjdk6.sh
+++ b/tests/scripts/mavenforopenjdk6.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Download and install a Maven version that works with OpenJDK6 under ubuntu Trusy
+echo "Downloading Maven 3.0";
+wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
+unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
+export M2_HOME=$PWD/apache-maven-3.0
+export PATH=$M2_HOME/bin:$PATH
+mvn -version
+mvn clean package install -DskipTests -Dgpg.skip


### PR DESCRIPTION
**ISLANDORA-2074**: (https://jira.duraspace.org/browse/ISLANDORA-2074)

http://irclogs.islandora.ca/2017-10-02.html

# What does this Pull Request do?

Changes the way openjdk6 is deployed on Travis-CI's Ubuntu trusty image, removes Oracle JDK7 and in a way of looking forward, adds Oracle JDK9 (experimental, allowing failures). 

# What's new?

Since September 2017, Ubuntu Trusty became the default Linux image for automated Travis-CI testing. When that happened our JAVA tests started failing because of new defaults, missing and also deprecated packages. Also, with the advent of JDK 9, Oracle removed JDK7 binaries from their download site (final-completely) leaving us without a binary source for that version.

# How should this be tested?

This auto-tests. If Travis-CI is green means we have tests passing. 

# Additional Notes:
If there are compelling reasons to force somehow OracleJDK7 to run here (with a how) by providing some (legal) alternative to the removed binaries, this is the place to speak out loud. Once this is approved and merged, a 7.x-1.10 release pull request will follow.
 
# Interested parties
@Islandora/7-x-1-x-committers @dhlamb @mjordan @adam-vessey @jonathangreen @rosiel 