### PR TITLE
Release 7.1.10 (Islandora 7.x-1.10 process) bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,57 @@
+dist: trusty
+#Docker container based
 sudo: false
 language: java
 cache:
   directories:
   - $HOME/.m2
+
 jdk:
-  - openjdk6
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
 env:
   - FEDORA_VERSION=3.6.2
   - FEDORA_VERSION=3.7.0
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
+matrix:
+  include:
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.6.2"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+         - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.7.0"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+        - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.7.1"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+        - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+     - jdk: openjdk6
+       env: FEDORA_VERSION="3.8.1"
+       addons:
+         apt:
+           packages:
+             - openjdk-6-jdk
+       install:
+       - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
+  allow_failures:
+    - jdk: oraclejdk9
+
 script:
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=travis -Ddb.pass=""
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=postgres -Ddb.pass="" -Ddb.port=5432 -Ddb.class="org.postgresql.Driver" -Ddb.scheme="jdbc:postgresql" -Ddb.group=postgresql -Ddb.artifact=postgresql -Ddb.version="9.1-901.jdbc4"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>ca.islandora</groupId>
     <artifactId>fcrepo-drupalauthfilter</artifactId>
     <name>Islandora Drupal Servlet Filters</name>
-    <version>7.1.10-SNAPSHOT</version>
+    <version>7.1.10</version>
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <skipTests>true</skipTests>

--- a/tests/scripts/mavenforopenjdk6.sh
+++ b/tests/scripts/mavenforopenjdk6.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Download and install a Maven version that works with OpenJDK6 under ubuntu Trusy
+echo "Downloading Maven 3.0";
+wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
+unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
+export M2_HOME=$PWD/apache-maven-3.0
+export PATH=$M2_HOME/bin:$PATH
+mvn -version
+mvn clean package install -DskipTests -Dgpg.skip


### PR DESCRIPTION
Islandora 7.x-1.10 release process bump. This involves moving this one to 7.1.10 out of snapshot. the `master`equivalent moves that branch to 7.1.11-snapshot

NOTE: VM release machine should actually use this filter version 

# Interested parties
@rosiel 