### PR TITLE
ISLANDORA-2393 Allowing SSL connection params to be set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,39 +16,6 @@ env:
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
 matrix:
-  include:
-     - jdk: openjdk6
-       env: FEDORA_VERSION="3.6.2"
-       addons:
-         apt:
-           packages:
-             - openjdk-6-jdk
-       install:
-         - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
-     - jdk: openjdk6
-       env: FEDORA_VERSION="3.7.0"
-       addons:
-         apt:
-           packages:
-             - openjdk-6-jdk
-       install:
-        - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
-     - jdk: openjdk6
-       env: FEDORA_VERSION="3.7.1"
-       addons:
-         apt:
-           packages:
-             - openjdk-6-jdk
-       install:
-        - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
-     - jdk: openjdk6
-       env: FEDORA_VERSION="3.8.1"
-       addons:
-         apt:
-           packages:
-             - openjdk-6-jdk
-       install:
-       - source $TRAVIS_BUILD_DIR/tests/scripts/mavenforopenjdk6.sh
   allow_failures:
     - jdk: oraclejdk9
 

--- a/filter-drupal.xml
+++ b/filter-drupal.xml
@@ -21,14 +21,21 @@
            - jdbcURLProtocol = "jdbc:mysql"
 
            postgresql users can set: jdbcDriverClass="org.postgresql.Driver" jdbcURLProtocol="jdbc:postgresql"
+
+           SSL connection params can be set:
+           - useSSL="true"
+           - requireSSL="true"
+           - verifyServerCertificate="true"
+           - trustCertificateKeyStoreUrl="file:///path/to/jks/truststore"
+           - trustCertificateKeyStorePassword="truststorepassword"
       -->
     <connection server="DB_SERVER" port="3306" dbname="DRUPAL_DB_NAME" user="DRUPAL_DB_USER" password="DRUPAL_DB_PASS">
-    <sql>
-        <!--Different sql statement for each connection.  This is for drupal 
-            multisites that are setup using one database with table prefixes.
-            We don't do this but some people might.-->
-       SELECT DISTINCT u.uid AS userid, u.name AS Name, u.pass AS Pass,r.name AS Role FROM (users u LEFT JOIN users_roles ON u.uid=users_roles.uid) LEFT JOIN role r ON r.rid=users_roles.rid WHERE u.name=? AND u.pass=?; 
-    </sql>
-    </connection>   
+        <sql>
+            <!--Different sql statement for each connection.  This is for drupal
+                multisites that are setup using one database with table prefixes.
+                We don't do this but some people might.-->
+            SELECT DISTINCT u.uid AS userid, u.name AS Name, u.pass AS Pass,r.name AS Role FROM (users u LEFT JOIN users_roles ON u.uid=users_roles.uid) LEFT JOIN role r ON r.rid=users_roles.rid WHERE u.name=? AND u.pass=?;
+        </sql>
+    </connection>
 </FilterDrupal_Connection>
 


### PR DESCRIPTION
ISLANDORA-2393 : https://jira.duraspace.org/browse/ISLANDORA-2393

https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html

Adding support for SSL connections to the drupal database integrated with a fedora repository. Apart for some spacing and a few comments it is just adding parsing of a few SSL connection params from the filter-drupal.xml and adding them onto to the jdbcUrl.
